### PR TITLE
Support returning an iterator from the repository method

### DIFF
--- a/src/GenericDoctrineSourceAdapter.php
+++ b/src/GenericDoctrineSourceAdapter.php
@@ -45,14 +45,11 @@ final class GenericDoctrineSourceAdapter implements SourceAdapter
     public function getObjectsOrderedById()
     {
         $entities = $this->repository->{$this->repositoryMethod}();
-        if (is_array($entities) === false) {
-            throw new \RuntimeException(
-                'The result of ' . get_class($this->repository) . '->' . $this->repositoryMethod . '() is no array, '
-                . 'which it has to be if you wish to use ' . __CLASS__
-            );
+
+        if (is_array($entities)) {
+            return new \ArrayIterator($entities);
         }
 
-        /** @var Collection mixed[] */
-        return new \ArrayIterator($entities);
+        return $entities;
     }
 }

--- a/src/GenericDoctrineSourceAdapter.php
+++ b/src/GenericDoctrineSourceAdapter.php
@@ -50,6 +50,10 @@ final class GenericDoctrineSourceAdapter implements SourceAdapter
             return new \ArrayIterator($entities);
         }
 
+        if (!is_iterable($entities)) {
+            throw new \RuntimeException('The repository method must return either an array or iterable');
+        }
+
         return $entities;
     }
 }


### PR DESCRIPTION
This way, `iterate` (deprecated) or `toIterable()` can be used to perform hydration row-by-row (see https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/reference/batch-processing.html#iterating-results).

Using an iterator is ~supported~ expected in the interface definition.