### PR TITLE
Update code, declare it in a way to be agnostic of ORM

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
 
     "require": {
         "php": ">= 8.1",
-        "webfactory/content-mapping": "^3.0",
-        "doctrine/persistence": "^2.0|^3.0|^4.0"
+        "webfactory/content-mapping": "^3.0"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     ],
 
     "require": {
-        "php": ">=5.3.0",
+        "php": ">= 8.1",
         "webfactory/content-mapping": "^3.0",
-        "doctrine/orm": "^2.1"
+        "doctrine/persistence": "^2.0|^3.0|^4.0"
     },
 
     "autoload": {

--- a/src/GenericDoctrineSourceAdapter.php
+++ b/src/GenericDoctrineSourceAdapter.php
@@ -8,9 +8,6 @@
 
 namespace Webfactory\ContentMapping\SourceAdapter\Doctrine;
 
-use ArrayIterator;
-use Doctrine\Persistence\ObjectRepository;
-use RuntimeException;
 use Webfactory\ContentMapping\SourceAdapter;
 
 /**
@@ -18,29 +15,16 @@ use Webfactory\ContentMapping\SourceAdapter;
  */
 final class GenericDoctrineSourceAdapter implements SourceAdapter
 {
-    /**
-     * @param non-empty-string $repositoryMethod
-     *
-     * @psalm-assert callable([$repository, $repositoryMethod]): iterable
-     */
     public function __construct(
-        private readonly ObjectRepository $repository,
+        private readonly object $repository,
         private readonly string $repositoryMethod = 'findForContentMapping'
     ) {
     }
 
-    public function getObjectsOrderedById(): iterable
+    public function getObjectsOrderedById(): \Iterator
     {
-        $entities = $this->repository->{$this->repositoryMethod}();
-
-        if (is_array($entities)) {
-            return new ArrayIterator($entities);
-        }
-
-        if (!is_iterable($entities)) {
-            throw new RuntimeException('The repository method must return either an array or iterable');
-        }
-
-        return $entities;
+        return (function () {
+            yield from $this->repository->{$this->repositoryMethod}();
+        })();
     }
 }

--- a/src/GenericDoctrineSourceAdapter.php
+++ b/src/GenericDoctrineSourceAdapter.php
@@ -8,50 +8,37 @@
 
 namespace Webfactory\ContentMapping\SourceAdapter\Doctrine;
 
-use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\EntityRepository;
+use ArrayIterator;
+use Doctrine\Persistence\ObjectRepository;
+use RuntimeException;
 use Webfactory\ContentMapping\SourceAdapter;
 
 /**
  * Implementation for Doctrine as a source system.
- *
- * @final by default.
  */
 final class GenericDoctrineSourceAdapter implements SourceAdapter
 {
     /**
-     * @var EntityRepository
+     * @param non-empty-string $repositoryMethod
+     *
+     * @psalm-assert callable([$repository, $repositoryMethod]): iterable
      */
-    private $repository;
-
-    /**
-     * @var string
-     */
-    private $repositoryMethod;
-
-    /**
-     * @param EntityRepository $repository to query
-     * @param string $repositoryMethod Which returns a Collection of all objects to map, ordered by their ascending IDs.
-     */
-    public function __construct($repository, $repositoryMethod = 'findForContentMapping')
-    {
-        $this->repository = $repository;
-        $this->repositoryMethod = $repositoryMethod;
+    public function __construct(
+        private readonly ObjectRepository $repository,
+        private readonly string $repositoryMethod = 'findForContentMapping'
+    ) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getObjectsOrderedById()
+    public function getObjectsOrderedById(): iterable
     {
         $entities = $this->repository->{$this->repositoryMethod}();
 
         if (is_array($entities)) {
-            return new \ArrayIterator($entities);
+            return new ArrayIterator($entities);
         }
 
         if (!is_iterable($entities)) {
-            throw new \RuntimeException('The repository method must return either an array or iterable');
+            throw new RuntimeException('The repository method must return either an array or iterable');
         }
 
         return $entities;


### PR DESCRIPTION
In fact, we don't care if the `$repository` is actually an `EntityRepository` or an `ObjectRepository`, and it does not have to be either.

As long as it returns an Iterator over source objects and those are ordered by ID (which is checked in the Synchronzier class), we're fine.